### PR TITLE
Added setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_packages
+__VERSION__ = "1.0.0"
+
+def requirements():
+    with open('requirements.txt') as reqs:
+        install_req = [line for line in reqs.read().split('\n')]
+    return install_req
+
+def readme():
+    with open("README.md") as f:
+        return f.read()
+
+setup(
+    name="TrustTree",
+    url="https://github.com/mandatoryprogrammer/TrustTrees",
+    description="A Tool for DNS Delegation Trust Graphing",
+    version=__VERSION__,
+    long_description=readme(),
+    keywords="trusttree, dns, dnssec",
+    author="mandatoryprogrammer",
+    packages=find_packages(),
+    install_requires=requirements(),
+    scripts=['trusttrees.py'],
+    include_package_data=True
+)


### PR DESCRIPTION
Added a setup.py to be able to install TrustTrees with pip.

Also it would be great if you could tag a release after merging this. That way, I could create a Homebrew formula for TrustTrees.