### PR TITLE
Refactor trusttrees.py, add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+    -   id: check-builtin-literals
+        args: ['--no-allow-dict-kwargs']
+    -   id: debug-statements
+    -   id: double-quote-string-fixer
+    -   id: end-of-file-fixer
+    -   id: name-tests-test
+    -   id: flake8
+        args: ['--max-line-length', '100']
+        exclude: ^test_data/
+    -   id: trailing-whitespace
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.3.4
+    hooks:
+    -   id: reorder-python-imports
+        language_version: python3
+-   repo: https://github.com/asottile/add-trailing-comma
+    rev: v0.7.1
+    hooks:
+    -   id: add-trailing-comma
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
+    hooks:
+    -   id: autopep8

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ In order to use the domain-check functionality to look for domain takeovers via 
 * *White Nameserver Nodes*: These are nameservers which have delegated the query to another nameserver and have not responded authoritatively to the query.
 * *Blue Nameserver Nodes*: These are nameservers which have answered authoritatively to the query.
 * *Red Nameserver Nodes*: These are nameserves which were found to have no IP address associated with them. They are essentially dead-ends because the resolver has no way to send queries to them.
-* *Yellow DNS Error Nodes*: These are DNS errors which occured while recursing the DNS chain. 
-* *Orange Domain Unregistered Nodes*: These nodes indicate that the base domain for the nameserver is reported by Gandi to be unregistered. This can mean the domain can be registered and the DNS hijacked! 
+* *Yellow DNS Error Nodes*: These are DNS errors which occured while recursing the DNS chain.
+* *Orange Domain Unregistered Nodes*: These nodes indicate that the base domain for the nameserver is reported by Gandi to be unregistered. This can mean the domain can be registered and the DNS hijacked!
 
 ### Edges
 * *Dashed gray lines*: This means that the query response was not authoritative.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
+ipdb
 pre-commit

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -7,6 +7,7 @@ import os
 import random
 import subprocess
 import time
+from collections import defaultdict
 
 import dns.flags
 import dns.rcode
@@ -25,48 +26,97 @@ RED = '#ff0000'
 ORANGE = '#ff7700'
 YELLOW = '#fff200'
 
-ROOT_SERVERS = [
-    {'ip': '198.41.0.4', 'hostname': 'a.root-servers.net.'},
-    {'ip': '192.228.79.201', 'hostname': 'b.root-servers.net.'},
-    {'ip': '192.33.4.12', 'hostname': 'c.root-servers.net.'},
-    {'ip': '199.7.91.13', 'hostname': 'd.root-servers.net.'},
-    {'ip': '192.203.230.10', 'hostname': 'e.root-servers.net.'},
-    {'ip': '192.5.5.241', 'hostname': 'f.root-servers.net.'},
-]
+ROOT_SERVERS = (
+    {
+        'ip': '198.41.0.4',
+        'hostname': 'a.root-servers.net.',
+    },
+    {
+        'ip': '192.228.79.201',
+        'hostname': 'b.root-servers.net.',
+    },
+    {
+        'ip': '192.33.4.12',
+        'hostname': 'c.root-servers.net.',
+    },
+    {
+        'ip': '199.7.91.13',
+        'hostname': 'd.root-servers.net.',
+    },
+    {
+        'ip': '192.203.230.10',
+        'hostname': 'e.root-servers.net.',
+    },
+    {
+        'ip': '192.5.5.241',
+        'hostname': 'f.root-servers.net.',
+    },
+    {
+        'ip': '192.112.36.4',
+        'hostname': 'g.root-servers.net.',
+    },
+    {
+        'ip': '198.97.190.53',
+        'hostname': 'h.root-servers.net.',
+    },
+    {
+        'ip': '192.36.148.17',
+        'hostname': 'i.root-servers.net.',
+    },
+    {
+        'ip': '192.58.128.30',
+        'hostname': 'j.root-servers.net.',
+    },
+    {
+        'ip': '193.0.14.129',
+        'hostname': 'k.root-servers.net.',
+    },
+    {
+        'ip': '199.7.83.42',
+        'hostname': 'l.root-servers.net.',
+    },
+    {
+        'ip': '202.12.27.33',
+        'hostname': 'm.root-servers.net.',
+    },
+)
 
 DNS_WATCH_RESOLVER = '84.200.69.80'
 DOMAIN_AVAILABILITY_CACHE = {}
 IPV6_ENABLED = False
 MAX_RECURSION_DEPTH = 4
-PREVIOUS_EDGES = []
+PREVIOUS_EDGES = set()
 
 """
 Saved results of DNS queries, key format is the following:
 
 KEY = FQDN_QUERY_NAME|QUERY_TYPE|NS_TARGET_IP
+
 e.g.
     "google.com.|ns|192.168.1.1"
 """
 MASTER_DNS_CACHE = {}
 
 """
-A key/value map of all the glue records we have seen.
+This creates an easy map of nameserver names to one of their IP addresses.
 
-This creates an easy map of nameserver names to IP addresses.
+It is used to check for nameservers without any IP addresses.
 
-Example:
-{
-    "ns1.example.com.": [ "192.168.1.1", "192.168.2.1" ],
-}
+e.g.
+    {
+        "ns1.example.com.": "192.168.1.1",
+        "ns2.example.com.": "",
+        ...
+    }
 """
-NS_IP_MAP = {}
+NS_IP_MAP = defaultdict(str)
 
 """
 A simple list of nameservers which were returned with the authoritative answer flag set.
 
 Used for graphing to make it clear where the flow of queries ends.
 """
-AUTHORITATIVE_NS_LIST = []
+AUTHORITATIVE_NS_SET = set()
 
 """
 A list of DNS errors returned whilst querying nameservers.
@@ -111,12 +161,12 @@ def get_random_root_ns_set():
 def dns_query(target_hostname, query_type, target_nameserver):
     res = dns.resolver.Resolver(configure=False)
     res.nameservers = [target_nameserver]
-    results = res.query(
+    result = res.query(
         qname=target_hostname,
         rdtype=query_type,
         raise_on_no_answer=False,
     )
-    return results
+    return result
 
 
 def is_authoritative(flags):
@@ -124,25 +174,69 @@ def is_authoritative(flags):
 
 
 def ns_query(hostname, nameserver_ip, nameserver_hostname):
+    """
+    This writes to MASTER_DNS_CACHE, which is
+    later read from in draw_graph_from_cache()
+    """
     if not hostname.endswith('.'):
         hostname += '.'
 
     # Normalize input query data
     hostname = hostname.lower()
 
-    # Create cache key and check if we have a cached version of this response.
-    cache_key = hostname + '|ns|' + nameserver_ip + '|' + nameserver_hostname
-
+    # Create cache key and check if we already cached this response
+    cache_key = '{}|ns|{}|{}'.format(
+        hostname,
+        nameserver_ip,
+        nameserver_hostname,
+    )
     if cache_key in MASTER_DNS_CACHE:
         return MASTER_DNS_CACHE[cache_key]
 
-    return_dict = _ns_query(hostname, nameserver_ip, nameserver_hostname)
-    MASTER_DNS_CACHE[cache_key] = return_dict
-
-    return return_dict
+    MASTER_DNS_CACHE[cache_key] = _ns_query(
+        hostname,
+        nameserver_ip,
+        nameserver_hostname,
+    )
+    return MASTER_DNS_CACHE[cache_key]
 
 
 def _ns_query(hostname, nameserver_ip, nameserver_hostname):
+    """
+    Performs the NS query.
+
+    Writes to
+        AUTHORITATIVE_NS_SET,
+        NS_IP_MAP
+        and QUERY_ERROR_LIST
+    which is later read from in get_graph_data_for_ns_result()
+
+    :returns: dictionary
+    e.g.
+         {
+             'nameserver_ip': '1.2.3.4',
+             'rcode_string': 'NOERROR',
+             'flags': [
+                 'QR',
+                 'RD'
+             ],
+             'authority_ns': [
+                 {
+                     'ns_ip': '5.6.7.8',
+                     'hostname': 'foo.',
+                     'ns_hostname': 'demand.alpha.aridns.net.au.',
+                     'ttl': 172800
+                 },
+                 ...
+            ],
+            'additional_ns': [],
+            'answer_ns': [],
+            'hostname': 'bar.foo.',
+            'rcode': 0,
+            'success': True,
+            'nameserver_hostname': 'g.root-servers.net.'
+        }
+    """
     print(
         "[ STATUS ] Querying nameserver '{}/{}' for NS of '{}'".format(
             nameserver_ip,
@@ -150,21 +244,7 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
             hostname,
         ),
     )
-
-    """
-    Return data in a more sane format.
-
-    {
-        "raw": ORIGINAL_RETURNED_VALUE,
-        "nameservers": [
-            {
-                "ip": "",
-                "hostname": "",
-                "ttl": "",
-            }
-        ]
-    }
-    """
+    dns_query_error = None
     return_dict = {
         'hostname': hostname,
         'nameserver_hostname': nameserver_hostname,
@@ -176,23 +256,25 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
         'success': False,
     }
 
-    dns_query_error = None
-
     try:
-        results = dns_query(hostname, 'NS', target_nameserver=nameserver_ip)
+        ns_result = dns_query(
+            hostname,
+            query_type='NS',
+            target_nameserver=nameserver_ip,
+        )
+    except dns.resolver.NoNameservers:
+        # TODO: This fucking blows, figure out a way to do this without an exception
+        dns_query_error = 'FATAL_ERROR'
+        return_dict['rcode'] = -1
     except dns.resolver.NXDOMAIN:
         dns_query_error = 'NXDOMAIN'
-        return_dict['rcode'] = 3
+        return_dict['rcode'] = dns.rcode.NXDOMAIN
     except dns.resolver.Timeout:
         dns_query_error = 'TIMEOUT'
         return_dict['rcode'] = -1
     except dns.resolver.YXDOMAIN:
         dns_query_error = 'YXDOMAIN'
-        return_dict['rcode'] = 6
-    except dns.resolver.NoNameservers:
-        # TODO: This fucking blows, figure out a way to do this without an exception.
-        dns_query_error = 'FATAL_ERROR'
-        return_dict['rcode'] = -1
+        return_dict['rcode'] = dns.rcode.YXDOMAIN
 
     if dns_query_error:
         return_dict['rcode_string'] = dns_query_error
@@ -205,16 +287,17 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
         )
         return return_dict
 
-    # If we have made it this far we can mark the response as successful.
+    # If we have made it this far, we can mark the response as successful
     return_dict['success'] = True
 
-    return_dict['flags'] = dns.flags.to_text(results.response.flags).split(' ')
-    return_dict['rcode'] = results.response.rcode()
+    return_dict['flags'] = dns.flags.to_text(
+        ns_result.response.flags,
+    ).split(' ')
+    return_dict['rcode'] = ns_result.response.rcode()
     return_dict['rcode_string'] = dns.rcode.to_text(return_dict['rcode'])
 
     # ADDITIONAL section of NS answer
-    ns_hostnames_with_ip = []
-    for rrset in results.response.additional:
+    for rrset in ns_result.response.additional:
         if rrset.rdtype != dns.rdatatype.NS:
             continue
         for rrset_value in rrset.items:
@@ -228,12 +311,8 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
             ns_hostname = str(rrset.name).lower()
 
             # Store this glue record in our NS_IP_MAP for later
-            if ns_hostname not in NS_IP_MAP:
-                NS_IP_MAP[ns_hostname] = []
-            if ns_ip not in NS_IP_MAP[ns_hostname]:
-                NS_IP_MAP[ns_hostname].append(ns_ip)
+            NS_IP_MAP[ns_hostname] = ns_ip
 
-            ns_hostnames_with_ip.append(str(rrset.name).lower())
             return_dict['additional_ns'].append(
                 {
                     'ns_ip': ns_ip,
@@ -242,21 +321,17 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
                 },
             )
 
-            # If this was an authoritative answer we need to save that for graphing.
-            if (
-                is_authoritative(return_dict['flags'])
-                and
-                ns_hostname not in AUTHORITATIVE_NS_LIST
-            ):
-                AUTHORITATIVE_NS_LIST.append(ns_hostname)
+            # If this was an authoritative answer, we need to save that for graphing
+            if is_authoritative(return_dict['flags']):
+                AUTHORITATIVE_NS_SET.add(ns_hostname)
 
     for section_of_NS_answer, corresponding_key in (
         (
-            results.response.authority,
+            ns_result.response.authority,
             'authority_ns',
         ),
         (
-            results.response.answer,
+            ns_result.response.answer,
             'answer_ns',
         ),
     ):
@@ -265,9 +340,6 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
                 continue
             for rrset_value in rrset.items:
                 ns_hostname = str(rrset_value).lower()
-                # Add this to our NS_IP_MAP as an empty entry
-                if ns_hostname not in NS_IP_MAP:
-                    NS_IP_MAP[ns_hostname] = []
 
                 ns_dict = {
                     'ns_hostname': ns_hostname,
@@ -275,29 +347,22 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
                     'hostname': str(rrset.name).lower(),
                 }
 
-                # Since NS results sometimes won't have a glue record we will have to retrieve it..
-                # First check out own DNS cache
-                # If that fails then just use our resolver to get the IP
-                ns_ip = False
+                # Since NS results sometimes do not have a glue record, we have to retrieve it..
+                # If ns_hostname is not in our DNS cache
+                if not NS_IP_MAP[ns_hostname]:
+                    # Send an A query to DNS_WATCH_RESOLVER to get the IP
+                    NS_IP_MAP[ns_hostname] = try_to_get_first_ip_for_hostname(
+                        ns_hostname,
+                    )
 
-                if len(NS_IP_MAP[ns_hostname]) == 0:
-                    NS_IP_MAP[ns_hostname] = get_hostname_ips(ns_hostname)
-
-                if len(NS_IP_MAP[ns_hostname]) > 0:
-                    ns_ip = NS_IP_MAP[ns_hostname][0]
-
-                if ns_ip:
-                    ns_dict['ns_ip'] = ns_ip
+                if NS_IP_MAP[ns_hostname]:
+                    ns_dict['ns_ip'] = NS_IP_MAP[ns_hostname]
 
                 return_dict[corresponding_key].append(ns_dict)
 
-                # If this was an authoritative answer we need to save that for graphing.
-                if (
-                    is_authoritative(return_dict['flags'])
-                    and
-                    ns_hostname not in AUTHORITATIVE_NS_LIST
-                ):
-                    AUTHORITATIVE_NS_LIST.append(ns_hostname)
+                # If this was an authoritative answer, we need to save that for graphing
+                if is_authoritative(return_dict['flags']):
+                    AUTHORITATIVE_NS_SET.add(ns_hostname)
 
     return return_dict
 
@@ -306,50 +371,55 @@ def enumerate_nameservers(domain_name):
     if not domain_name.endswith('.'):
         domain_name += '.'
 
-    # First get a random root server and query it to bootstrap our walk of the chain.
+    # First get a random root server and query it to bootstrap our walk of the chain
     root_ns_set = get_random_root_ns_set()
-    tld_ns_results = ns_query(
-        domain_name, root_ns_set['ip'], root_ns_set['hostname'],
+    tld_ns_result = ns_query(
+        hostname=domain_name,
+        nameserver_ip=root_ns_set['ip'],
+        nameserver_hostname=root_ns_set['hostname'],
+    )
+    _recursively_enumerate_nameservers(
+        domain_name,
+        previous_ns_result=tld_ns_result,
     )
 
-    return _enumerate_nameservers(domain_name, tld_ns_results)
 
-
-def _enumerate_nameservers(domain_name, previous_ns_result, depth=0):
+def _recursively_enumerate_nameservers(domain_name, previous_ns_result, depth=0):
     """
-    Take the previous DNS results and do DNS queries against all of the returned nameservers.
+    Take the previous NS result and do NS queries against all of the returned nameservers.
     """
-    for section_of_NS_answer, check_for_ns_ip in (
-        (
-            previous_ns_result['additional_ns'],
-            False,
-        ),
-        (
-            previous_ns_result['answer_ns'],
-            True,
-        ),
-        (
-            previous_ns_result['authority_ns'],
-            True,
-        ),
+    for section_of_NS_answer in (
+        'additional_ns',
+        'answer_ns',
+        'authority_ns',
     ):
-        for ns_rrset in section_of_NS_answer:
+        for ns_rrset in previous_ns_result[section_of_NS_answer]:
             if (
-                check_for_ns_ip
+                section_of_NS_answer != 'additional_ns'
                 and
                 'ns_ip' not in ns_rrset
             ):
                 continue
-            ns_results = ns_query(
-                domain_name, ns_rrset['ns_ip'], ns_rrset['ns_hostname'],
+            ns_result = ns_query(
+                hostname=domain_name,
+                nameserver_ip=ns_rrset['ns_ip'],
+                nameserver_hostname=ns_rrset['ns_hostname'],
             )
             if depth < MAX_RECURSION_DEPTH:
-                _enumerate_nameservers(
-                    domain_name, ns_results, (depth + 1),
+                _recursively_enumerate_nameservers(
+                    domain_name,
+                    previous_ns_result=ns_result,
+                    depth=depth + 1,
                 )
 
 
 def draw_graph_from_cache(target_hostname):
+    """
+    Iterates through MASTER_DNS_CACHE, and calls get_graph_data_for_ns_result()
+
+    :returns: string
+    For pygraphviz.AGraph()
+    """
     GRAPH_DATA = (
         """
         digraph G {{
@@ -366,47 +436,47 @@ def draw_graph_from_cache(target_hostname):
         """.format(target_hostname)
     )
 
-    for cache_key, ns_results in MASTER_DNS_CACHE.iteritems():
+    for cache_key, ns_result in MASTER_DNS_CACHE.iteritems():
         print("[ STATUS ] Building '" + cache_key + "'...")
-        for ns_list in (
-            ns_results['authority_ns'],
-            ns_results['additional_ns'],
-            ns_results['answer_ns'],
+        for section_of_NS_answer in (
+            'additional_ns',
+            'authority_ns',
+            'answer_ns',
         ):
-            GRAPH_DATA += get_graph_data_for_ns_results(
-                ns_list,
-                ns_results,
+            GRAPH_DATA += get_graph_data_for_ns_result(
+                ns_list=ns_result[section_of_NS_answer],
+                ns_result=ns_result,
             )
 
     GRAPH_DATA += '\n}'
     return GRAPH_DATA
 
 
-def get_graph_data_for_ns_results(ns_list, ns_results):
+def get_graph_data_for_ns_result(ns_list, ns_result):
     return_graph_data_string = ''
 
     for ns_rrset in ns_list:
         potential_edge = (
-            ns_results['nameserver_hostname'] + '->' + ns_rrset['ns_hostname']
+            ns_result['nameserver_hostname'] + '->' + ns_rrset['ns_hostname']
         )
 
         if potential_edge not in PREVIOUS_EDGES:
-            PREVIOUS_EDGES.append(potential_edge)
+            PREVIOUS_EDGES.add(potential_edge)
             return_graph_data_string += (
                 '"{}" -> "{}" [shape=ellipse]'.format(
-                    ns_results['nameserver_hostname'],
+                    ns_result['nameserver_hostname'],
                     ns_rrset['ns_hostname'],
                 )
             )
 
             return_graph_data_string += (
                 '[label=<<i>{}?</i><br /><font point-size="10">{}</font>>] '.format(
-                    ns_results['hostname'],
-                    ns_results['rcode_string'],
+                    ns_result['hostname'],
+                    ns_result['rcode_string'],
                 )
             )
 
-            if is_authoritative(ns_results['flags']):
+            if is_authoritative(ns_result['flags']):
                 return_graph_data_string += '[color="{}"] '.format(BLUE)
             else:
                 return_graph_data_string += '[style="dashed", color="{}"] '.format(
@@ -415,8 +485,8 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
 
             return_graph_data_string += ';\n'
 
-    # Make all nameservers which were specified with an AA flag blue.
-    for ns_hostname in AUTHORITATIVE_NS_LIST:
+    # Make all nameservers which were specified with an AA flag blue
+    for ns_hostname in AUTHORITATIVE_NS_SET:
         return_graph_data_string += (
             '"{}" [shape=ellipse, style=filled, fillcolor="{}"];\n'.format(
                 ns_hostname,
@@ -424,9 +494,9 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
             )
         )
 
-    # Make all nameservers without any IP red because they might be vulnerable.
-    for ns_hostname, ns_hostname_ip_list in NS_IP_MAP.iteritems():
-        if len(ns_hostname_ip_list) == 0:
+    # Make all nameservers without any IPs red because they might be vulnerable
+    for ns_hostname, ns_hostname_ip in NS_IP_MAP.iteritems():
+        if not ns_hostname_ip:
             return_graph_data_string += (
                 '"{}" [shape=ellipse, style=filled, fillcolor="{}"];\n'.format(
                     ns_hostname,
@@ -435,11 +505,15 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
             )
 
         base_domain = get_base_domain(ns_hostname)
-        if GANDI_API_KEY != '' and is_domain_available(base_domain):
+        if (
+            GANDI_API_KEY
+            and
+            is_domain_available(base_domain)
+        ):
             node_name = "Base domain '" + base_domain + "' unregisted!"
             potential_edge = ns_hostname + '->' + node_name
             if potential_edge not in PREVIOUS_EDGES:
-                PREVIOUS_EDGES.append(potential_edge)
+                PREVIOUS_EDGES.add(potential_edge)
                 return_graph_data_string += (
                     '"{}" -> "{}";\n'.format(
                         ns_hostname,
@@ -463,7 +537,7 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
         )
 
         if potential_edge not in PREVIOUS_EDGES:
-            PREVIOUS_EDGES.append(potential_edge)
+            PREVIOUS_EDGES.add(potential_edge)
             return_graph_data_string += (
                 '"{}" -> "{}" '.format(
                     query_error['ns_hostname'],
@@ -486,18 +560,24 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
     return return_graph_data_string
 
 
-def get_hostname_ips(hostname):
-    return_ips = []
+def try_to_get_first_ip_for_hostname(hostname):
+    """
+    :returns: string
+    e.g.
+        "1.2.3.4"
+    """
     try:
-        answer = dns_query(hostname, 'A', target_nameserver=DNS_WATCH_RESOLVER)
+        answer = dns_query(
+            hostname,
+            query_type='A',
+            target_nameserver=DNS_WATCH_RESOLVER,
+        )
         if answer.rrset:
-            for rrset in answer.rrset:
-                return_ips.append(str(rrset))
+            return str(answer.rrset[0])
     # TODO: Catch specific exception(s)
     except Exception:
-        return []
-
-    return return_ips
+        pass
+    return ''
 
 
 def print_logo():

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -16,33 +16,15 @@ from pprint import pprint
 from subprocess import call as subprocess_call
 import pygraphviz as pgv
 
-gandi_api = xmlrpclib.ServerProxy( "https://rpc.gandi.net/xmlrpc/" )
+gandi_api = xmlrpclib.ServerProxy("https://rpc.gandi.net/xmlrpc/")
 
 ROOT_SERVERS = [
-    {
-        "ip": "198.41.0.4",
-        "hostname": "a.root-servers.net.",
-    },
-    {
-        "ip": "192.228.79.201",
-        "hostname": "b.root-servers.net.",
-    },
-    {
-        "ip": "192.33.4.12",
-        "hostname": "c.root-servers.net.",
-    },
-    {
-        "ip": "199.7.91.13",
-        "hostname": "d.root-servers.net.",
-    },
-    {
-        "ip": "192.203.230.10",
-        "hostname": "e.root-servers.net.",
-    },
-    {
-        "ip": "192.5.5.241",
-        "hostname": "f.root-servers.net.",
-    }
+    {"ip": "198.41.0.4", "hostname": "a.root-servers.net."},
+    {"ip": "192.228.79.201", "hostname": "b.root-servers.net."},
+    {"ip": "192.33.4.12", "hostname": "c.root-servers.net."},
+    {"ip": "199.7.91.13", "hostname": "d.root-servers.net."},
+    {"ip": "192.203.230.10", "hostname": "e.root-servers.net."},
+    {"ip": "192.5.5.241", "hostname": "f.root-servers.net."},
 ]
 
 DOMAIN_AVAILABILITY_CACHE = {}
@@ -89,57 +71,66 @@ QUERY_ERROR_LIST = []
 
 GANDI_API_KEY = ""
 
-def is_domain_available( input_domain ):
-    if input_domain.endswith( "." ):
+
+def is_domain_available(input_domain):
+    if input_domain.endswith("."):
         input_domain = input_domain[:-1]
 
     if input_domain in DOMAIN_AVAILABILITY_CACHE:
-        return DOMAIN_AVAILABILITY_CACHE[ input_domain ]
+        return DOMAIN_AVAILABILITY_CACHE[input_domain]
 
-    print( "[ STATUS ] Checking if " + input_domain + " is available..." )
+    print("[ STATUS ] Checking if " + input_domain + " is available...")
 
-    result = gandi_api.domain.available( GANDI_API_KEY, [ input_domain ] )
+    result = gandi_api.domain.available(GANDI_API_KEY, [input_domain])
     counter = 0
-    while result[ input_domain ] == "pending" and counter < 10:
+    while result[input_domain] == "pending" and counter < 10:
         counter += 1
-        time.sleep( 1 )
-        result = gandi_api.domain.available( GANDI_API_KEY, [ input_domain ] )
+        time.sleep(1)
+        result = gandi_api.domain.available(GANDI_API_KEY, [input_domain])
 
-    domain_available = ( result[ input_domain ] == "available" )
+    domain_available = result[input_domain] == "available"
 
-    DOMAIN_AVAILABILITY_CACHE[ input_domain ] = domain_available
+    DOMAIN_AVAILABILITY_CACHE[input_domain] = domain_available
 
     return domain_available
 
-def get_tld_from_domain( input_hostname ):
-    tldexact_parts = tldextract.extract( "http://" + input_hostname )
+
+def get_tld_from_domain(input_hostname):
+    tldexact_parts = tldextract.extract("http://" + input_hostname)
     return tldexact_parts.suffix + "."
 
-def get_base_domain( input_hostname ):
-    tldexact_parts = tldextract.extract( "http://" + input_hostname )
+
+def get_base_domain(input_hostname):
+    tldexact_parts = tldextract.extract("http://" + input_hostname)
     return tldexact_parts.domain + "." + tldexact_parts.suffix + "."
 
-def pprint( input_dict ):
-    print( json.dumps( input_dict, sort_keys=True, indent=4, separators=( ",", ": " ) ) )
+
+def pprint(input_dict):
+    print(json.dumps(input_dict, sort_keys=True, indent=4, separators=(",", ": ")))
+
 
 def dump(obj):
-  for attr in dir(obj):
-    print( "obj.%s = %s" % (attr, getattr(obj, attr)) )
+    for attr in dir(obj):
+        print("obj.%s = %s" % (attr, getattr(obj, attr)))
+
 
 def get_random_root_ns_set():
-    return random.choice( ROOT_SERVERS )
+    return random.choice(ROOT_SERVERS)
 
-def dns_query( target_hostname, query_type, target_nameserver ):
-    res = dns.resolver.Resolver( configure=False )
-    res.nameservers = [ target_nameserver ]
-    results = res.query( target_hostname, query_type, raise_on_no_answer=False )
+
+def dns_query(target_hostname, query_type, target_nameserver):
+    res = dns.resolver.Resolver(configure=False)
+    res.nameservers = [target_nameserver]
+    results = res.query(target_hostname, query_type, raise_on_no_answer=False)
     return results
 
-def is_authoratative( flags ):
-    return ( "AA" in flags )
 
-def ns_query( hostname, nameserver_ip, nameserver_hostname ):
-    if not hostname.endswith( "." ):
+def is_authoratative(flags):
+    return "AA" in flags
+
+
+def ns_query(hostname, nameserver_ip, nameserver_hostname):
+    if not hostname.endswith("."):
         hostname += "."
 
     # Normalize input query data
@@ -149,15 +140,24 @@ def ns_query( hostname, nameserver_ip, nameserver_hostname ):
     cache_key = hostname + "|ns|" + nameserver_ip + "|" + nameserver_hostname
 
     if cache_key in MASTER_DNS_CACHE:
-        return MASTER_DNS_CACHE[ cache_key ]
+        return MASTER_DNS_CACHE[cache_key]
 
-    return_dict = _ns_query( hostname, nameserver_ip, nameserver_hostname )
-    MASTER_DNS_CACHE[ cache_key ] = return_dict
+    return_dict = _ns_query(hostname, nameserver_ip, nameserver_hostname)
+    MASTER_DNS_CACHE[cache_key] = return_dict
 
     return return_dict
 
-def _ns_query( hostname, nameserver_ip, nameserver_hostname ):
-    print( "[ STATUS ] Querying nameserver '" + nameserver_ip + "/" + nameserver_hostname + "' for NS of '" + hostname + "'" )
+
+def _ns_query(hostname, nameserver_ip, nameserver_hostname):
+    print(
+        "[ STATUS ] Querying nameserver '"
+        + nameserver_ip
+        + "/"
+        + nameserver_hostname
+        + "' for NS of '"
+        + hostname
+        + "'"
+    )
 
     """
     Return data in a more sane format.
@@ -187,62 +187,70 @@ def _ns_query( hostname, nameserver_ip, nameserver_hostname ):
     dns_query_error_occured = False
 
     try:
-        results = dns_query( hostname, "NS", nameserver_ip )
+        results = dns_query(hostname, "NS", nameserver_ip)
     except dns.resolver.NXDOMAIN:
         dns_query_error_occured = "NXDOMAIN"
-        return_dict[ "rcode" ] = 3
+        return_dict["rcode"] = 3
     except dns.resolver.Timeout:
         dns_query_error_occured = "TIMEOUT"
-        return_dict[ "rcode" ] = -1
+        return_dict["rcode"] = -1
     except dns.resolver.YXDOMAIN:
         dns_query_error_occured = "YXDOMAIN"
-        return_dict[ "rcode" ] = 6
+        return_dict["rcode"] = 6
     except dns.resolver.NoNameservers:
         # TODO, this fucking blows, figure out a way to do this without an exception.
         dns_query_error_occured = "FATAL_ERROR"
-        return_dict[ "rcode" ] = -1
+        return_dict["rcode"] = -1
 
     if dns_query_error_occured:
-        return_dict[ "rcode_string" ] = dns_query_error_occured
-        QUERY_ERROR_LIST.append({
-            "hostname": hostname,
-            "error": dns_query_error_occured,
-            "ns_hostname": nameserver_hostname
-        })
+        return_dict["rcode_string"] = dns_query_error_occured
+        QUERY_ERROR_LIST.append(
+            {
+                "hostname": hostname,
+                "error": dns_query_error_occured,
+                "ns_hostname": nameserver_hostname,
+            }
+        )
         return return_dict
 
     # If we've made it this far we can mark the response as successful.
-    return_dict[ "success" ] = True
+    return_dict["success"] = True
 
-    return_dict[ "flags" ] = dns.flags.to_text( results.response.flags ).split( " " )
-    return_dict[ "rcode" ] = results.response.rcode()
-    return_dict[ "rcode_string" ] = dns.rcode.to_text( return_dict[ "rcode" ] )
+    return_dict["flags"] = dns.flags.to_text(results.response.flags).split(" ")
+    return_dict["rcode"] = results.response.rcode()
+    return_dict["rcode_string"] = dns.rcode.to_text(return_dict["rcode"])
 
     # ADDITIONAL section of NS answer
     ns_hostnames_with_ip = []
     for rrset in results.response.additional:
         if rrset.rdtype == 2:
             for rrset_value in rrset.items:
-                if ( ":" in str( rrset_value ) and IPV6_ENABLED ) or ( not ":" in str( rrset_value ) ):
-                    ns_ip = str( rrset_value ).lower()
-                    ns_hostname = str( rrset.name ).lower()
+                if (":" in str(rrset_value) and IPV6_ENABLED) or (
+                    not ":" in str(rrset_value)
+                ):
+                    ns_ip = str(rrset_value).lower()
+                    ns_hostname = str(rrset.name).lower()
 
                     # Store this glue record in our NS_IP_MAP for later
                     if not ns_hostname in NS_IP_MAP:
-                        NS_IP_MAP[ ns_hostname ] = []
-                    if not ns_ip in NS_IP_MAP[ ns_hostname ]:
-                        NS_IP_MAP[ ns_hostname ].append( ns_ip )
+                        NS_IP_MAP[ns_hostname] = []
+                    if not ns_ip in NS_IP_MAP[ns_hostname]:
+                        NS_IP_MAP[ns_hostname].append(ns_ip)
 
-                    ns_hostnames_with_ip.append( str( rrset.name ).lower() )
-                    return_dict[ "additional_ns" ].append({
-                        "ns_ip": ns_ip,
-                        "ttl": int( rrset.ttl ),
-                        "ns_hostname": ns_hostname,
-                    })
+                    ns_hostnames_with_ip.append(str(rrset.name).lower())
+                    return_dict["additional_ns"].append(
+                        {
+                            "ns_ip": ns_ip,
+                            "ttl": int(rrset.ttl),
+                            "ns_hostname": ns_hostname,
+                        }
+                    )
 
                     # If this was an authoratative answer we need to save that for graphing.
-                    if is_authoratative( return_dict[ "flags" ] ) and not ( ns_hostname in AUTHORITATIVE_NS_LIST ):
-                        AUTHORITATIVE_NS_LIST.append( ns_hostname )
+                    if is_authoratative(return_dict["flags"]) and not (
+                        ns_hostname in AUTHORITATIVE_NS_LIST
+                    ):
+                        AUTHORITATIVE_NS_LIST.append(ns_hostname)
 
     # TODO: DRY this up somehow vvv
 
@@ -250,214 +258,308 @@ def _ns_query( hostname, nameserver_ip, nameserver_hostname ):
     for rrset in results.response.authority:
         if rrset.rdtype == 2:
             for rrset_value in rrset.items:
-                ns_hostname = str( rrset_value ).lower()
+                ns_hostname = str(rrset_value).lower()
                 # Add this to our NS_IP_MAP as an empty entry
                 if not ns_hostname in NS_IP_MAP:
-                    NS_IP_MAP[ ns_hostname ] = []
+                    NS_IP_MAP[ns_hostname] = []
 
                 ns_dict = {
                     "ns_hostname": ns_hostname,
-                    "ttl": int( rrset.ttl ),
-                    "hostname": str( rrset.name ).lower(),
+                    "ttl": int(rrset.ttl),
+                    "hostname": str(rrset.name).lower(),
                 }
 
                 # Since NS results sometimes won't have a glue record we will have to retrieve it..
                 # First check out own DNS cache, if that fails then just use our resolver to get the IP.
                 ns_ip = False
 
-                if len( NS_IP_MAP[ ns_hostname ] ) == 0 :
-                    NS_IP_MAP[ ns_hostname ] = get_hostname_ips( ns_hostname )
+                if len(NS_IP_MAP[ns_hostname]) == 0:
+                    NS_IP_MAP[ns_hostname] = get_hostname_ips(ns_hostname)
 
-                if len( NS_IP_MAP[ ns_hostname ] ) > 0 :
-                    ns_ip = NS_IP_MAP[ ns_hostname ][0]
+                if len(NS_IP_MAP[ns_hostname]) > 0:
+                    ns_ip = NS_IP_MAP[ns_hostname][0]
 
                 if ns_ip:
-                    ns_dict[ "ns_ip" ] = ns_ip
+                    ns_dict["ns_ip"] = ns_ip
 
-                return_dict[ "authority_ns" ].append( ns_dict )
+                return_dict["authority_ns"].append(ns_dict)
 
                 # If this was an authoratative answer we need to save that for graphing.
-                if is_authoratative( return_dict[ "flags" ] ) and not ( ns_hostname in AUTHORITATIVE_NS_LIST ):
-                    AUTHORITATIVE_NS_LIST.append( ns_hostname )
+                if is_authoratative(return_dict["flags"]) and not (
+                    ns_hostname in AUTHORITATIVE_NS_LIST
+                ):
+                    AUTHORITATIVE_NS_LIST.append(ns_hostname)
 
     # ANSWER section of NS answer
     for rrset in results.response.answer:
         if rrset.rdtype == 2:
             for rrset_value in rrset.items:
-                ns_hostname = str( rrset_value ).lower()
+                ns_hostname = str(rrset_value).lower()
                 # Add this to our NS_IP_MAP as an empty entry
                 if not ns_hostname in NS_IP_MAP:
-                    NS_IP_MAP[ ns_hostname ] = []
+                    NS_IP_MAP[ns_hostname] = []
 
                 ns_dict = {
                     "ns_hostname": ns_hostname,
-                    "ttl": int( rrset.ttl ),
-                    "hostname": str( rrset.name ).lower(),
+                    "ttl": int(rrset.ttl),
+                    "hostname": str(rrset.name).lower(),
                 }
 
                 # Since NS results sometimes won't have a glue record we will have to retrieve it..
                 # First check out own DNS cache, if that fails then just use our resolver to get the IP.
                 ns_ip = False
 
-                if len( NS_IP_MAP[ ns_hostname ] ) == 0 :
-                    NS_IP_MAP[ ns_hostname ] = get_hostname_ips( ns_hostname )
+                if len(NS_IP_MAP[ns_hostname]) == 0:
+                    NS_IP_MAP[ns_hostname] = get_hostname_ips(ns_hostname)
 
-                if len( NS_IP_MAP[ ns_hostname ] ) > 0 :
-                    ns_ip = NS_IP_MAP[ ns_hostname ][0]
+                if len(NS_IP_MAP[ns_hostname]) > 0:
+                    ns_ip = NS_IP_MAP[ns_hostname][0]
 
                 if ns_ip:
-                    ns_dict[ "ns_ip" ] = ns_ip
+                    ns_dict["ns_ip"] = ns_ip
 
-                return_dict[ "answer_ns" ].append( ns_dict )
+                return_dict["answer_ns"].append(ns_dict)
 
                 # If this was an authoratative answer we need to save that for graphing.
-                if is_authoratative( return_dict[ "flags" ] ) and not ( ns_hostname in AUTHORITATIVE_NS_LIST ):
-                    AUTHORITATIVE_NS_LIST.append( ns_hostname )
+                if is_authoratative(return_dict["flags"]) and not (
+                    ns_hostname in AUTHORITATIVE_NS_LIST
+                ):
+                    AUTHORITATIVE_NS_LIST.append(ns_hostname)
 
     # TODO: DRY this up somehow ^^^
 
     return return_dict
 
-def enumerate_nameservers( domain_name ):
-    if not domain_name.endswith( "." ):
+
+def enumerate_nameservers(domain_name):
+    if not domain_name.endswith("."):
         domain_name += "."
 
     # First get a random root server and query it to bootstrap our walk of the chain.
     root_ns_set = get_random_root_ns_set()
-    tld_ns_results = ns_query( domain_name, root_ns_set[ "ip" ], root_ns_set[ "hostname" ] )
+    tld_ns_results = ns_query(domain_name, root_ns_set["ip"], root_ns_set["hostname"])
 
-    return _enumerate_nameservers( domain_name, tld_ns_results, 0, MAX_RECURSION_DEPTH )
+    return _enumerate_nameservers(domain_name, tld_ns_results, 0, MAX_RECURSION_DEPTH)
 
-def _enumerate_nameservers( domain_name, previous_ns_result, depth, max_depth ):
+
+def _enumerate_nameservers(domain_name, previous_ns_result, depth, max_depth):
     # Take the previous DNS results and do DNS queries against all of the returned nameservers.
 
     # Start with NS returned in ADDITIONAL section of answer.
-    for ns_rrset in previous_ns_result[ "additional_ns" ]:
-        ns_results = ns_query( domain_name, ns_rrset[ "ns_ip" ], ns_rrset[ "ns_hostname" ] )
+    for ns_rrset in previous_ns_result["additional_ns"]:
+        ns_results = ns_query(domain_name, ns_rrset["ns_ip"], ns_rrset["ns_hostname"])
 
         if depth < max_depth:
-            _enumerate_nameservers( domain_name, ns_results, ( depth + 1 ), max_depth )
+            _enumerate_nameservers(domain_name, ns_results, (depth + 1), max_depth)
 
-    for ns_rrset in previous_ns_result[ "answer_ns" ]:
+    for ns_rrset in previous_ns_result["answer_ns"]:
         if "ns_ip" in ns_rrset:
-            ns_results = ns_query( domain_name, ns_rrset[ "ns_ip" ], ns_rrset[ "ns_hostname" ] )
+            ns_results = ns_query(
+                domain_name, ns_rrset["ns_ip"], ns_rrset["ns_hostname"]
+            )
 
             if depth < max_depth:
-                _enumerate_nameservers( domain_name, ns_results, ( depth + 1 ), max_depth )
+                _enumerate_nameservers(domain_name, ns_results, (depth + 1), max_depth)
 
-    for ns_rrset in previous_ns_result[ "authority_ns" ]:
+    for ns_rrset in previous_ns_result["authority_ns"]:
         if "ns_ip" in ns_rrset:
-            ns_results = ns_query( domain_name, ns_rrset[ "ns_ip" ], ns_rrset[ "ns_hostname" ] )
+            ns_results = ns_query(
+                domain_name, ns_rrset["ns_ip"], ns_rrset["ns_hostname"]
+            )
 
             if depth < max_depth:
-                _enumerate_nameservers( domain_name, ns_results, ( depth + 1 ), max_depth )
+                _enumerate_nameservers(domain_name, ns_results, (depth + 1), max_depth)
 
-def draw_graph_from_cache( target_hostname ):
-    GRAPH_DATA = """
+
+def draw_graph_from_cache(target_hostname):
+    GRAPH_DATA = (
+        """
 digraph G {
-graph [ label=\"""" + target_hostname + """ DNS Trust Graph\", labelloc="t", pad="3", nodesep="1", ranksep="5", fontsize=50];
+graph [ label=\""""
+        + target_hostname
+        + """ DNS Trust Graph\", labelloc="t", pad="3", nodesep="1", ranksep="5", fontsize=50];
 edge[arrowhead=vee, arrowtail=inv, arrowsize=.7]
 concentrate=true;
 """
+    )
     for cache_key, ns_results in MASTER_DNS_CACHE.iteritems():
-        print( "[ STATUS ] Building '" + cache_key + "'...")
-        GRAPH_DATA += get_graph_data_for_ns_results( ns_results[ "authority_ns" ], ns_results )
-        GRAPH_DATA += get_graph_data_for_ns_results( ns_results[ "additional_ns" ], ns_results )
-        GRAPH_DATA += get_graph_data_for_ns_results( ns_results[ "answer_ns" ], ns_results )
+        print("[ STATUS ] Building '" + cache_key + "'...")
+        GRAPH_DATA += get_graph_data_for_ns_results(
+            ns_results["authority_ns"], ns_results
+        )
+        GRAPH_DATA += get_graph_data_for_ns_results(
+            ns_results["additional_ns"], ns_results
+        )
+        GRAPH_DATA += get_graph_data_for_ns_results(ns_results["answer_ns"], ns_results)
 
     GRAPH_DATA += "\n}"
     return GRAPH_DATA
 
-def get_graph_data_for_ns_results( ns_list, ns_results ):
+
+def get_graph_data_for_ns_results(ns_list, ns_results):
     return_graph_data_string = ""
 
     for ns_rrset in ns_list:
-        potential_edge = ns_results[ "nameserver_hostname" ] + "->" + ns_rrset[ "ns_hostname" ]
+        potential_edge = (
+            ns_results["nameserver_hostname"] + "->" + ns_rrset["ns_hostname"]
+        )
 
         if not potential_edge in PREVIOUS_EDGES:
-            PREVIOUS_EDGES.append( potential_edge )
-            return_graph_data_string += "\"" + ns_results[ "nameserver_hostname" ] + "\" -> \"" + ns_rrset[ "ns_hostname" ] + "\" [shape=ellipse]"
+            PREVIOUS_EDGES.append(potential_edge)
+            return_graph_data_string += (
+                '"'
+                + ns_results["nameserver_hostname"]
+                + '" -> "'
+                + ns_rrset["ns_hostname"]
+                + '" [shape=ellipse]'
+            )
 
-            return_graph_data_string += "[label=<<i>" + ns_results[ "hostname" ] + "?</i><br /><font point-size=\"10\">" + ns_results[ "rcode_string" ] + "</font>>] "
+            return_graph_data_string += (
+                "[label=<<i>"
+                + ns_results["hostname"]
+                + '?</i><br /><font point-size="10">'
+                + ns_results["rcode_string"]
+                + "</font>>] "
+            )
 
-            if not "AA" in ns_results[ "flags" ]:
-                return_graph_data_string += "[style=\"dashed\", color=\"#a3a3a3\"] "
+            if not "AA" in ns_results["flags"]:
+                return_graph_data_string += '[style="dashed", color="#a3a3a3"] '
             else:
-                return_graph_data_string += "[color=\"#0099ff\"] "
+                return_graph_data_string += '[color="#0099ff"] '
 
             return_graph_data_string += ";\n"
 
     # Make all nameservers which were specified with an AA flag blue.
     for ns_hostname in AUTHORITATIVE_NS_LIST:
-        return_graph_data_string += "\"" + ns_hostname + "\" [shape=ellipse, style=filled, fillcolor=\"#0099ff\"];\n"
+        return_graph_data_string += (
+            '"'
+            + ns_hostname
+            + '" [shape=ellipse, style=filled, fillcolor="#0099ff"];\n'
+        )
 
     # Make all nameservers without any IP red because they might be vulnerable.
     for ns_hostname, ns_hostname_ip_list in NS_IP_MAP.iteritems():
-        if len( ns_hostname_ip_list ) == 0:
-            return_graph_data_string += "\"" + ns_hostname + "\" [shape=ellipse, style=filled, fillcolor=\"#ff0000\"];\n"
+        if len(ns_hostname_ip_list) == 0:
+            return_graph_data_string += (
+                '"'
+                + ns_hostname
+                + '" [shape=ellipse, style=filled, fillcolor="#ff0000"];\n'
+            )
 
-        base_domain = get_base_domain( ns_hostname )
-        if GANDI_API_KEY != "" and is_domain_available( base_domain ):
+        base_domain = get_base_domain(ns_hostname)
+        if GANDI_API_KEY != "" and is_domain_available(base_domain):
             node_name = "Base domain '" + base_domain + "' unregisted!"
             potential_edge = ns_hostname + "->" + node_name
             if not potential_edge in PREVIOUS_EDGES:
-                PREVIOUS_EDGES.append( potential_edge )
-                return_graph_data_string += "\"" + ns_hostname + "\" -> \"" + node_name + "\";\n"
-                return_graph_data_string += "\"" + node_name + "\"[shape=octagon, style=filled, fillcolor=\"#ff7700\"];\n"
+                PREVIOUS_EDGES.append(potential_edge)
+                return_graph_data_string += (
+                    '"' + ns_hostname + '" -> "' + node_name + '";\n'
+                )
+                return_graph_data_string += (
+                    '"'
+                    + node_name
+                    + '"[shape=octagon, style=filled, fillcolor="#ff7700"];\n'
+                )
 
     # Make nodes for DNS error states encountered like NXDOMAIN, Timeout, etc.
     for query_error in QUERY_ERROR_LIST:
-        potential_edge = query_error[ "ns_hostname" ] + "->" + query_error[ "error" ]
+        potential_edge = query_error["ns_hostname"] + "->" + query_error["error"]
 
         if not potential_edge in PREVIOUS_EDGES:
-            PREVIOUS_EDGES.append( potential_edge )
-            return_graph_data_string += "\"" + query_error[ "ns_hostname" ] + "\" -> \"" + query_error[ "error" ] + "\" "
-            return_graph_data_string += "[label=<<i>" + query_error[ "hostname" ] + "?</i><br /><font point-size=\"10\">" + query_error[ "error" ] + "</font>>];\n"
-            return_graph_data_string += "\"" + query_error[ "error" ] + "\" [shape=octagon, style=filled, fillcolor=\"#fff200\"];\n"
+            PREVIOUS_EDGES.append(potential_edge)
+            return_graph_data_string += (
+                '"'
+                + query_error["ns_hostname"]
+                + '" -> "'
+                + query_error["error"]
+                + '" '
+            )
+            return_graph_data_string += (
+                "[label=<<i>"
+                + query_error["hostname"]
+                + '?</i><br /><font point-size="10">'
+                + query_error["error"]
+                + "</font>>];\n"
+            )
+            return_graph_data_string += (
+                '"'
+                + query_error["error"]
+                + '" [shape=octagon, style=filled, fillcolor="#fff200"];\n'
+            )
 
     return return_graph_data_string
 
 
-def write_file( file_name, file_data ):
-    file_handler = open( file_name, "w" )
-    file_handler.write( file_data )
+def write_file(file_name, file_data):
+    file_handler = open(file_name, "w")
+    file_handler.write(file_data)
     file_handler.close()
     return
 
-def read_file( file_name ):
-    file_handler = open( file_name, "r" )
+
+def read_file(file_name):
+    file_handler = open(file_name, "r")
     contents = file_handler.read()
     file_handler.close()
     return contents
 
-def get_hostname_ips( hostname ):
+
+def get_hostname_ips(hostname):
     return_ips = []
     try:
-        answer = dns_query( hostname, "A", DEFAULT_RESOLVER )
+        answer = dns_query(hostname, "A", DEFAULT_RESOLVER)
         if answer.rrset:
             for rrset in answer.rrset:
-                return_ips.append( str( rrset ) )
+                return_ips.append(str(rrset))
     except:
         return []
 
     return return_ips
 
+
 def print_logo():
-    print( """
+    print(
+        """
   ______                __ ______
  /_  __/______  _______/ //_  __/_______  ___  _____
   / / / ___/ / / / ___/ __// / / ___/ _ \/ _ \/ ___/
  / / / /  / /_/ (__  ) /_ / / / /  /  __/  __(__  )
 /_/ /_/   \__,_/____/\__//_/ /_/   \___/\___/____/
           Graphing & Scanning DNS Delegation Trees
-""")
+"""
+    )
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser( description="Graph out a domain's DNS delegation chain and trust trees!" )
-    parser.add_argument( "-t", "--target", dest="target_hostname", help="Target hostname to generate delegation graph from.", required=True )
-    parser.add_argument( "-o", "--open", dest="open", help="Open the generated graph once run.", action="store_true" )
-    parser.add_argument( "-dc", "--domain-check", dest="domain_check", help="Check if nameserver base domains are expired. Specify a Gandi API key." )
-    parser.add_argument( "-x", "--export-formats", dest="export_formats", help="Comma-seperated export formats, e.g: -x png,pdf" )
+    parser = argparse.ArgumentParser(
+        description="Graph out a domain's DNS delegation chain and trust trees!"
+    )
+    parser.add_argument(
+        "-t",
+        "--target",
+        dest="target_hostname",
+        help="Target hostname to generate delegation graph from.",
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        "--open",
+        dest="open",
+        help="Open the generated graph once run.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-dc",
+        "--domain-check",
+        dest="domain_check",
+        help="Check if nameserver base domains are expired. Specify a Gandi API key.",
+    )
+    parser.add_argument(
+        "-x",
+        "--export-formats",
+        dest="export_formats",
+        help="Comma-seperated export formats, e.g: -x png,pdf",
+    )
     args = parser.parse_args()
 
     print_logo()
@@ -467,22 +569,20 @@ if __name__ == "__main__":
 
     target_hostname = args.target_hostname
 
-    enumerate_nameservers( target_hostname )
+    enumerate_nameservers(target_hostname)
 
     # Render graph image
-    grapher = pgv.AGraph(
-        draw_graph_from_cache( target_hostname )
-    )
+    grapher = pgv.AGraph(draw_graph_from_cache(target_hostname))
 
     output_graph_file = "./output/" + target_hostname + "_trust_tree_graph."
 
     export_formats = []
     if args.export_formats:
-        export_parts = args.export_formats.split( "," )
+        export_parts = args.export_formats.split(",")
         for part in export_parts:
-            export_formats.append( part.strip() )
+            export_formats.append(part.strip())
     else:
-        export_formats.append( "png" )
+        export_formats.append("png")
 
     for export_format in export_formats:
         file_name = output_graph_file + export_format
@@ -491,9 +591,9 @@ if __name__ == "__main__":
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-        grapher.draw( file_name, prog="dot" )
+        grapher.draw(file_name, prog="dot")
         if args.open:
-            print( "[ STATUS ] Opening final graph..." )
-            subprocess_call( [ "open", file_name ])
+            print("[ STATUS ] Opening final graph...")
+            subprocess_call(["open", file_name])
 
-    print( "[ SUCCESS ] Finished generating graph!" )
+    print("[ SUCCESS ] Finished generating graph!")

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -10,6 +10,7 @@ import time
 
 import dns.flags
 import dns.rcode
+import dns.rdatatype
 import dns.resolver
 import pygraphviz as pgv
 import tldextract
@@ -215,7 +216,7 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
     # ADDITIONAL section of NS answer
     ns_hostnames_with_ip = []
     for rrset in results.response.additional:
-        if rrset.rdtype != 2:
+        if rrset.rdtype != dns.rdatatype.NS:
             continue
         for rrset_value in rrset.items:
             if (
@@ -261,7 +262,7 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
         ),
     ):
         for rrset in section_of_NS_answer:
-            if rrset.rdtype != 2:
+            if rrset.rdtype != dns.rdatatype.NS:
                 continue
             for rrset_value in rrset.items:
                 ns_hostname = str(rrset_value).lower()

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -1,45 +1,44 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import dns.resolver
-import tldextract
+
+import argparse
+import errno
+import json
+import os
+import random
+import subprocess
+import time
+
 import dns.flags
 import dns.rcode
-import xmlrpclib
-import argparse
-import random
-import json
-import time
-import sys
-import os
-import errno
-from pprint import pprint
-from subprocess import call as subprocess_call
+import dns.resolver
 import pygraphviz as pgv
+import tldextract
+import xmlrpclib
 
-gandi_api = xmlrpclib.ServerProxy("https://rpc.gandi.net/xmlrpc/")
+gandi_api = xmlrpclib.ServerProxy('https://rpc.gandi.net/xmlrpc/')
 
 ROOT_SERVERS = [
-    {"ip": "198.41.0.4", "hostname": "a.root-servers.net."},
-    {"ip": "192.228.79.201", "hostname": "b.root-servers.net."},
-    {"ip": "192.33.4.12", "hostname": "c.root-servers.net."},
-    {"ip": "199.7.91.13", "hostname": "d.root-servers.net."},
-    {"ip": "192.203.230.10", "hostname": "e.root-servers.net."},
-    {"ip": "192.5.5.241", "hostname": "f.root-servers.net."},
+    {'ip': '198.41.0.4', 'hostname': 'a.root-servers.net.'},
+    {'ip': '192.228.79.201', 'hostname': 'b.root-servers.net.'},
+    {'ip': '192.33.4.12', 'hostname': 'c.root-servers.net.'},
+    {'ip': '199.7.91.13', 'hostname': 'd.root-servers.net.'},
+    {'ip': '192.203.230.10', 'hostname': 'e.root-servers.net.'},
+    {'ip': '192.5.5.241', 'hostname': 'f.root-servers.net.'},
 ]
 
 DOMAIN_AVAILABILITY_CACHE = {}
 MAX_RECURSION_DEPTH = 4
 IPV6_ENABLED = False
-DEFAULT_RESOLVER = "84.200.69.80"
+DEFAULT_RESOLVER = '84.200.69.80'
 PREVIOUS_EDGES = []
 
 """
 Saved results of DNS queries, key format is the following:
 
 KEY = FQDN_QUERY_NAME|QUERY_TYPE|NS_TARGET_IP
-
-Example:
-KEY = "google.com.|ns|192.168.1.1"
+e.g.
+    "google.com.|ns|192.168.1.1"
 """
 MASTER_DNS_CACHE = {}
 
@@ -69,26 +68,26 @@ This is used in graphing to show where the flow breaks.
 """
 QUERY_ERROR_LIST = []
 
-GANDI_API_KEY = ""
+GANDI_API_KEY = ''
 
 
 def is_domain_available(input_domain):
-    if input_domain.endswith("."):
+    if input_domain.endswith('.'):
         input_domain = input_domain[:-1]
 
     if input_domain in DOMAIN_AVAILABILITY_CACHE:
         return DOMAIN_AVAILABILITY_CACHE[input_domain]
 
-    print("[ STATUS ] Checking if " + input_domain + " is available...")
+    print('[ STATUS ] Checking if ' + input_domain + ' is available...')
 
     result = gandi_api.domain.available(GANDI_API_KEY, [input_domain])
     counter = 0
-    while result[input_domain] == "pending" and counter < 10:
+    while result[input_domain] == 'pending' and counter < 10:
         counter += 1
         time.sleep(1)
         result = gandi_api.domain.available(GANDI_API_KEY, [input_domain])
 
-    domain_available = result[input_domain] == "available"
+    domain_available = result[input_domain] == 'available'
 
     DOMAIN_AVAILABILITY_CACHE[input_domain] = domain_available
 
@@ -96,22 +95,22 @@ def is_domain_available(input_domain):
 
 
 def get_tld_from_domain(input_hostname):
-    tldexact_parts = tldextract.extract("http://" + input_hostname)
-    return tldexact_parts.suffix + "."
+    tldexact_parts = tldextract.extract('http://' + input_hostname)
+    return tldexact_parts.suffix + '.'
 
 
 def get_base_domain(input_hostname):
-    tldexact_parts = tldextract.extract("http://" + input_hostname)
-    return tldexact_parts.domain + "." + tldexact_parts.suffix + "."
+    tldexact_parts = tldextract.extract('http://' + input_hostname)
+    return tldexact_parts.domain + '.' + tldexact_parts.suffix + '.'
 
 
 def pprint(input_dict):
-    print(json.dumps(input_dict, sort_keys=True, indent=4, separators=(",", ": ")))
+    print(json.dumps(input_dict, sort_keys=True, indent=4, separators=(',', ': ')))
 
 
 def dump(obj):
     for attr in dir(obj):
-        print("obj.%s = %s" % (attr, getattr(obj, attr)))
+        print('obj.%s = %s' % (attr, getattr(obj, attr)))
 
 
 def get_random_root_ns_set():
@@ -126,18 +125,18 @@ def dns_query(target_hostname, query_type, target_nameserver):
 
 
 def is_authoratative(flags):
-    return "AA" in flags
+    return 'AA' in flags
 
 
 def ns_query(hostname, nameserver_ip, nameserver_hostname):
-    if not hostname.endswith("."):
-        hostname += "."
+    if not hostname.endswith('.'):
+        hostname += '.'
 
     # Normalize input query data
     hostname = hostname.lower()
 
     # Create cache key and check if we have a cached version of this response.
-    cache_key = hostname + "|ns|" + nameserver_ip + "|" + nameserver_hostname
+    cache_key = hostname + '|ns|' + nameserver_ip + '|' + nameserver_hostname
 
     if cache_key in MASTER_DNS_CACHE:
         return MASTER_DNS_CACHE[cache_key]
@@ -152,11 +151,11 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
     print(
         "[ STATUS ] Querying nameserver '"
         + nameserver_ip
-        + "/"
+        + '/'
         + nameserver_hostname
         + "' for NS of '"
         + hostname
-        + "'"
+        + "'",
     )
 
     """
@@ -174,80 +173,84 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
     }
     """
     return_dict = {
-        "hostname": hostname,
-        "nameserver_hostname": nameserver_hostname,
-        "nameserver_ip": nameserver_ip,
-        "additional_ns": [],
-        "authority_ns": [],
-        "answer_ns": [],
-        "flags": [],
-        "success": False,
+        'hostname': hostname,
+        'nameserver_hostname': nameserver_hostname,
+        'nameserver_ip': nameserver_ip,
+        'additional_ns': [],
+        'authority_ns': [],
+        'answer_ns': [],
+        'flags': [],
+        'success': False,
     }
 
     dns_query_error_occured = False
 
     try:
-        results = dns_query(hostname, "NS", nameserver_ip)
+        results = dns_query(hostname, 'NS', nameserver_ip)
     except dns.resolver.NXDOMAIN:
-        dns_query_error_occured = "NXDOMAIN"
-        return_dict["rcode"] = 3
+        dns_query_error_occured = 'NXDOMAIN'
+        return_dict['rcode'] = 3
     except dns.resolver.Timeout:
-        dns_query_error_occured = "TIMEOUT"
-        return_dict["rcode"] = -1
+        dns_query_error_occured = 'TIMEOUT'
+        return_dict['rcode'] = -1
     except dns.resolver.YXDOMAIN:
-        dns_query_error_occured = "YXDOMAIN"
-        return_dict["rcode"] = 6
+        dns_query_error_occured = 'YXDOMAIN'
+        return_dict['rcode'] = 6
     except dns.resolver.NoNameservers:
         # TODO, this fucking blows, figure out a way to do this without an exception.
-        dns_query_error_occured = "FATAL_ERROR"
-        return_dict["rcode"] = -1
+        dns_query_error_occured = 'FATAL_ERROR'
+        return_dict['rcode'] = -1
 
     if dns_query_error_occured:
-        return_dict["rcode_string"] = dns_query_error_occured
+        return_dict['rcode_string'] = dns_query_error_occured
         QUERY_ERROR_LIST.append(
             {
-                "hostname": hostname,
-                "error": dns_query_error_occured,
-                "ns_hostname": nameserver_hostname,
-            }
+                'hostname': hostname,
+                'error': dns_query_error_occured,
+                'ns_hostname': nameserver_hostname,
+            },
         )
         return return_dict
 
     # If we've made it this far we can mark the response as successful.
-    return_dict["success"] = True
+    return_dict['success'] = True
 
-    return_dict["flags"] = dns.flags.to_text(results.response.flags).split(" ")
-    return_dict["rcode"] = results.response.rcode()
-    return_dict["rcode_string"] = dns.rcode.to_text(return_dict["rcode"])
+    return_dict['flags'] = dns.flags.to_text(results.response.flags).split(' ')
+    return_dict['rcode'] = results.response.rcode()
+    return_dict['rcode_string'] = dns.rcode.to_text(return_dict['rcode'])
 
     # ADDITIONAL section of NS answer
     ns_hostnames_with_ip = []
     for rrset in results.response.additional:
         if rrset.rdtype == 2:
             for rrset_value in rrset.items:
-                if (":" in str(rrset_value) and IPV6_ENABLED) or (
-                    not ":" in str(rrset_value)
+                if (
+                    ':' in str(rrset_value)
+                    and
+                    IPV6_ENABLED
+                ) or (
+                    ':' not in str(rrset_value)
                 ):
                     ns_ip = str(rrset_value).lower()
                     ns_hostname = str(rrset.name).lower()
 
                     # Store this glue record in our NS_IP_MAP for later
-                    if not ns_hostname in NS_IP_MAP:
+                    if ns_hostname not in NS_IP_MAP:
                         NS_IP_MAP[ns_hostname] = []
-                    if not ns_ip in NS_IP_MAP[ns_hostname]:
+                    if ns_ip not in NS_IP_MAP[ns_hostname]:
                         NS_IP_MAP[ns_hostname].append(ns_ip)
 
                     ns_hostnames_with_ip.append(str(rrset.name).lower())
-                    return_dict["additional_ns"].append(
+                    return_dict['additional_ns'].append(
                         {
-                            "ns_ip": ns_ip,
-                            "ttl": int(rrset.ttl),
-                            "ns_hostname": ns_hostname,
-                        }
+                            'ns_ip': ns_ip,
+                            'ttl': int(rrset.ttl),
+                            'ns_hostname': ns_hostname,
+                        },
                     )
 
                     # If this was an authoratative answer we need to save that for graphing.
-                    if is_authoratative(return_dict["flags"]) and not (
+                    if is_authoratative(return_dict['flags']) and not (
                         ns_hostname in AUTHORITATIVE_NS_LIST
                     ):
                         AUTHORITATIVE_NS_LIST.append(ns_hostname)
@@ -260,17 +263,18 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
             for rrset_value in rrset.items:
                 ns_hostname = str(rrset_value).lower()
                 # Add this to our NS_IP_MAP as an empty entry
-                if not ns_hostname in NS_IP_MAP:
+                if ns_hostname not in NS_IP_MAP:
                     NS_IP_MAP[ns_hostname] = []
 
                 ns_dict = {
-                    "ns_hostname": ns_hostname,
-                    "ttl": int(rrset.ttl),
-                    "hostname": str(rrset.name).lower(),
+                    'ns_hostname': ns_hostname,
+                    'ttl': int(rrset.ttl),
+                    'hostname': str(rrset.name).lower(),
                 }
 
                 # Since NS results sometimes won't have a glue record we will have to retrieve it..
-                # First check out own DNS cache, if that fails then just use our resolver to get the IP.
+                # First check out own DNS cache
+                # If that fails then just use our resolver to get the IP
                 ns_ip = False
 
                 if len(NS_IP_MAP[ns_hostname]) == 0:
@@ -280,12 +284,12 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
                     ns_ip = NS_IP_MAP[ns_hostname][0]
 
                 if ns_ip:
-                    ns_dict["ns_ip"] = ns_ip
+                    ns_dict['ns_ip'] = ns_ip
 
-                return_dict["authority_ns"].append(ns_dict)
+                return_dict['authority_ns'].append(ns_dict)
 
                 # If this was an authoratative answer we need to save that for graphing.
-                if is_authoratative(return_dict["flags"]) and not (
+                if is_authoratative(return_dict['flags']) and not (
                     ns_hostname in AUTHORITATIVE_NS_LIST
                 ):
                     AUTHORITATIVE_NS_LIST.append(ns_hostname)
@@ -296,17 +300,18 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
             for rrset_value in rrset.items:
                 ns_hostname = str(rrset_value).lower()
                 # Add this to our NS_IP_MAP as an empty entry
-                if not ns_hostname in NS_IP_MAP:
+                if ns_hostname not in NS_IP_MAP:
                     NS_IP_MAP[ns_hostname] = []
 
                 ns_dict = {
-                    "ns_hostname": ns_hostname,
-                    "ttl": int(rrset.ttl),
-                    "hostname": str(rrset.name).lower(),
+                    'ns_hostname': ns_hostname,
+                    'ttl': int(rrset.ttl),
+                    'hostname': str(rrset.name).lower(),
                 }
 
                 # Since NS results sometimes won't have a glue record we will have to retrieve it..
-                # First check out own DNS cache, if that fails then just use our resolver to get the IP.
+                # First check out own DNS cache
+                # If that fails then just use our resolver to get the IP
                 ns_ip = False
 
                 if len(NS_IP_MAP[ns_hostname]) == 0:
@@ -316,12 +321,12 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
                     ns_ip = NS_IP_MAP[ns_hostname][0]
 
                 if ns_ip:
-                    ns_dict["ns_ip"] = ns_ip
+                    ns_dict['ns_ip'] = ns_ip
 
-                return_dict["answer_ns"].append(ns_dict)
+                return_dict['answer_ns'].append(ns_dict)
 
                 # If this was an authoratative answer we need to save that for graphing.
-                if is_authoratative(return_dict["flags"]) and not (
+                if is_authoratative(return_dict['flags']) and not (
                     ns_hostname in AUTHORITATIVE_NS_LIST
                 ):
                     AUTHORITATIVE_NS_LIST.append(ns_hostname)
@@ -332,102 +337,116 @@ def _ns_query(hostname, nameserver_ip, nameserver_hostname):
 
 
 def enumerate_nameservers(domain_name):
-    if not domain_name.endswith("."):
-        domain_name += "."
+    if not domain_name.endswith('.'):
+        domain_name += '.'
 
     # First get a random root server and query it to bootstrap our walk of the chain.
     root_ns_set = get_random_root_ns_set()
-    tld_ns_results = ns_query(domain_name, root_ns_set["ip"], root_ns_set["hostname"])
+    tld_ns_results = ns_query(
+        domain_name, root_ns_set['ip'], root_ns_set['hostname'],
+    )
 
     return _enumerate_nameservers(domain_name, tld_ns_results, 0, MAX_RECURSION_DEPTH)
 
 
 def _enumerate_nameservers(domain_name, previous_ns_result, depth, max_depth):
-    # Take the previous DNS results and do DNS queries against all of the returned nameservers.
+    """
+    Take the previous DNS results and do DNS queries against all of the returned nameservers.
+    """
 
     # Start with NS returned in ADDITIONAL section of answer.
-    for ns_rrset in previous_ns_result["additional_ns"]:
-        ns_results = ns_query(domain_name, ns_rrset["ns_ip"], ns_rrset["ns_hostname"])
+    for ns_rrset in previous_ns_result['additional_ns']:
+        ns_results = ns_query(
+            domain_name, ns_rrset['ns_ip'], ns_rrset['ns_hostname'],
+        )
 
         if depth < max_depth:
-            _enumerate_nameservers(domain_name, ns_results, (depth + 1), max_depth)
+            _enumerate_nameservers(
+                domain_name, ns_results, (depth + 1), max_depth,
+            )
 
-    for ns_rrset in previous_ns_result["answer_ns"]:
-        if "ns_ip" in ns_rrset:
+    for ns_rrset in previous_ns_result['answer_ns']:
+        if 'ns_ip' in ns_rrset:
             ns_results = ns_query(
-                domain_name, ns_rrset["ns_ip"], ns_rrset["ns_hostname"]
+                domain_name, ns_rrset['ns_ip'], ns_rrset['ns_hostname'],
             )
 
             if depth < max_depth:
-                _enumerate_nameservers(domain_name, ns_results, (depth + 1), max_depth)
+                _enumerate_nameservers(
+                    domain_name, ns_results, (depth + 1), max_depth,
+                )
 
-    for ns_rrset in previous_ns_result["authority_ns"]:
-        if "ns_ip" in ns_rrset:
+    for ns_rrset in previous_ns_result['authority_ns']:
+        if 'ns_ip' in ns_rrset:
             ns_results = ns_query(
-                domain_name, ns_rrset["ns_ip"], ns_rrset["ns_hostname"]
+                domain_name, ns_rrset['ns_ip'], ns_rrset['ns_hostname'],
             )
 
             if depth < max_depth:
-                _enumerate_nameservers(domain_name, ns_results, (depth + 1), max_depth)
+                _enumerate_nameservers(
+                    domain_name, ns_results, (depth + 1), max_depth,
+                )
 
 
 def draw_graph_from_cache(target_hostname):
     GRAPH_DATA = (
         """
-digraph G {
-graph [ label=\""""
+        digraph G {
+        graph [ label=\""""
         + target_hostname
         + """ DNS Trust Graph\", labelloc="t", pad="3", nodesep="1", ranksep="5", fontsize=50];
-edge[arrowhead=vee, arrowtail=inv, arrowsize=.7]
-concentrate=true;
-"""
+        edge[arrowhead=vee, arrowtail=inv, arrowsize=.7]
+        concentrate=true;
+        """
     )
     for cache_key, ns_results in MASTER_DNS_CACHE.iteritems():
         print("[ STATUS ] Building '" + cache_key + "'...")
         GRAPH_DATA += get_graph_data_for_ns_results(
-            ns_results["authority_ns"], ns_results
+            ns_results['authority_ns'], ns_results,
         )
         GRAPH_DATA += get_graph_data_for_ns_results(
-            ns_results["additional_ns"], ns_results
+            ns_results['additional_ns'], ns_results,
         )
-        GRAPH_DATA += get_graph_data_for_ns_results(ns_results["answer_ns"], ns_results)
+        GRAPH_DATA += get_graph_data_for_ns_results(
+            ns_results['answer_ns'], ns_results,
+        )
 
-    GRAPH_DATA += "\n}"
+    GRAPH_DATA += '\n}'
     return GRAPH_DATA
 
 
 def get_graph_data_for_ns_results(ns_list, ns_results):
-    return_graph_data_string = ""
+    return_graph_data_string = ''
 
     for ns_rrset in ns_list:
         potential_edge = (
-            ns_results["nameserver_hostname"] + "->" + ns_rrset["ns_hostname"]
+            ns_results['nameserver_hostname'] + '->' + ns_rrset['ns_hostname']
         )
 
-        if not potential_edge in PREVIOUS_EDGES:
+        if potential_edge not in PREVIOUS_EDGES:
             PREVIOUS_EDGES.append(potential_edge)
             return_graph_data_string += (
                 '"'
-                + ns_results["nameserver_hostname"]
+                + ns_results['nameserver_hostname']
                 + '" -> "'
-                + ns_rrset["ns_hostname"]
+                + ns_rrset['ns_hostname']
                 + '" [shape=ellipse]'
             )
 
             return_graph_data_string += (
-                "[label=<<i>"
-                + ns_results["hostname"]
+                '[label=<<i>'
+                + ns_results['hostname']
                 + '?</i><br /><font point-size="10">'
-                + ns_results["rcode_string"]
-                + "</font>>] "
+                + ns_results['rcode_string']
+                + '</font>>] '
             )
 
-            if not "AA" in ns_results["flags"]:
+            if 'AA' not in ns_results['flags']:
                 return_graph_data_string += '[style="dashed", color="#a3a3a3"] '
             else:
                 return_graph_data_string += '[color="#0099ff"] '
 
-            return_graph_data_string += ";\n"
+            return_graph_data_string += ';\n'
 
     # Make all nameservers which were specified with an AA flag blue.
     for ns_hostname in AUTHORITATIVE_NS_LIST:
@@ -447,10 +466,10 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
             )
 
         base_domain = get_base_domain(ns_hostname)
-        if GANDI_API_KEY != "" and is_domain_available(base_domain):
+        if GANDI_API_KEY != '' and is_domain_available(base_domain):
             node_name = "Base domain '" + base_domain + "' unregisted!"
-            potential_edge = ns_hostname + "->" + node_name
-            if not potential_edge in PREVIOUS_EDGES:
+            potential_edge = ns_hostname + '->' + node_name
+            if potential_edge not in PREVIOUS_EDGES:
                 PREVIOUS_EDGES.append(potential_edge)
                 return_graph_data_string += (
                     '"' + ns_hostname + '" -> "' + node_name + '";\n'
@@ -463,27 +482,31 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
 
     # Make nodes for DNS error states encountered like NXDOMAIN, Timeout, etc.
     for query_error in QUERY_ERROR_LIST:
-        potential_edge = query_error["ns_hostname"] + "->" + query_error["error"]
+        potential_edge = (
+            query_error['ns_hostname']
+            + '->'
+            + query_error['error']
+        )
 
-        if not potential_edge in PREVIOUS_EDGES:
+        if potential_edge not in PREVIOUS_EDGES:
             PREVIOUS_EDGES.append(potential_edge)
             return_graph_data_string += (
                 '"'
-                + query_error["ns_hostname"]
+                + query_error['ns_hostname']
                 + '" -> "'
-                + query_error["error"]
+                + query_error['error']
                 + '" '
             )
             return_graph_data_string += (
-                "[label=<<i>"
-                + query_error["hostname"]
+                '[label=<<i>'
+                + query_error['hostname']
                 + '?</i><br /><font point-size="10">'
-                + query_error["error"]
-                + "</font>>];\n"
+                + query_error['error']
+                + '</font>>];\n'
             )
             return_graph_data_string += (
                 '"'
-                + query_error["error"]
+                + query_error['error']
                 + '" [shape=octagon, style=filled, fillcolor="#fff200"];\n'
             )
 
@@ -491,14 +514,13 @@ def get_graph_data_for_ns_results(ns_list, ns_results):
 
 
 def write_file(file_name, file_data):
-    file_handler = open(file_name, "w")
+    file_handler = open(file_name, 'w')
     file_handler.write(file_data)
     file_handler.close()
-    return
 
 
 def read_file(file_name):
-    file_handler = open(file_name, "r")
+    file_handler = open(file_name, 'r')
     contents = file_handler.read()
     file_handler.close()
     return contents
@@ -507,58 +529,57 @@ def read_file(file_name):
 def get_hostname_ips(hostname):
     return_ips = []
     try:
-        answer = dns_query(hostname, "A", DEFAULT_RESOLVER)
+        answer = dns_query(hostname, 'A', DEFAULT_RESOLVER)
         if answer.rrset:
             for rrset in answer.rrset:
                 return_ips.append(str(rrset))
-    except:
+    # TODO: Catch specific exception(s)
+    except Exception:
         return []
 
     return return_ips
 
 
 def print_logo():
-    print(
-        """
-  ______                __ ______
- /_  __/______  _______/ //_  __/_______  ___  _____
-  / / / ___/ / / / ___/ __// / / ___/ _ \/ _ \/ ___/
- / / / /  / /_/ (__  ) /_ / / / /  /  __/  __(__  )
-/_/ /_/   \__,_/____/\__//_/ /_/   \___/\___/____/
-          Graphing & Scanning DNS Delegation Trees
-"""
-    )
+    print("""
+      ______                __ ______
+     /_  __/______  _______/ //_  __/_______  ___  _____
+      / / / ___/ / / / ___/ __// / / ___/ _ \\/ _ \\/ ___/
+     / / / /  / /_/ (__  ) /_ / / / /  /  __/  __(__  )
+    /_/ /_/   \\__,_/____/\\__//_/ /_/   \\___/\\___/____/
+              Graphing & Scanning DNS Delegation Trees
+    """)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description="Graph out a domain's DNS delegation chain and trust trees!"
+        description="Graph out a domain's DNS delegation chain and trust trees!",
     )
     parser.add_argument(
-        "-t",
-        "--target",
-        dest="target_hostname",
-        help="Target hostname to generate delegation graph from.",
+        '-t',
+        '--target',
+        dest='target_hostname',
+        help='Target hostname to generate delegation graph from.',
         required=True,
     )
     parser.add_argument(
-        "-o",
-        "--open",
-        dest="open",
-        help="Open the generated graph once run.",
-        action="store_true",
+        '-o',
+        '--open',
+        dest='open',
+        help='Open the generated graph once run.',
+        action='store_true',
     )
     parser.add_argument(
-        "-dc",
-        "--domain-check",
-        dest="domain_check",
-        help="Check if nameserver base domains are expired. Specify a Gandi API key.",
+        '-dc',
+        '--domain-check',
+        dest='domain_check',
+        help='Check if nameserver base domains are expired. Specify a Gandi API key.',
     )
     parser.add_argument(
-        "-x",
-        "--export-formats",
-        dest="export_formats",
-        help="Comma-seperated export formats, e.g: -x png,pdf",
+        '-x',
+        '--export-formats',
+        dest='export_formats',
+        help='Comma-seperated export formats, e.g: -x png,pdf',
     )
     args = parser.parse_args()
 
@@ -574,26 +595,26 @@ if __name__ == "__main__":
     # Render graph image
     grapher = pgv.AGraph(draw_graph_from_cache(target_hostname))
 
-    output_graph_file = "./output/" + target_hostname + "_trust_tree_graph."
+    output_graph_file = './output/' + target_hostname + '_trust_tree_graph.'
 
     export_formats = []
     if args.export_formats:
-        export_parts = args.export_formats.split(",")
+        export_parts = args.export_formats.split(',')
         for part in export_parts:
             export_formats.append(part.strip())
     else:
-        export_formats.append("png")
+        export_formats.append('png')
 
     for export_format in export_formats:
         file_name = output_graph_file + export_format
         try:
-            os.mkdir("output")
+            os.mkdir('output')
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-        grapher.draw(file_name, prog="dot")
+        grapher.draw(file_name, prog='dot')
         if args.open:
-            print("[ STATUS ] Opening final graph...")
-            subprocess_call(["open", file_name])
+            print('[ STATUS ] Opening final graph...')
+            subprocess.call(['open', file_name])
 
-    print("[ SUCCESS ] Finished generating graph!")
+    print('[ SUCCESS ] Finished generating graph!')

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import dns.resolver
 import tldextract
 import dns.flags
@@ -123,7 +124,7 @@ def pprint( input_dict ):
 
 def dump(obj):
   for attr in dir(obj):
-    print "obj.%s = %s" % (attr, getattr(obj, attr))
+    print( "obj.%s = %s" % (attr, getattr(obj, attr)) )
 
 def get_random_root_ns_set():
     return random.choice( ROOT_SERVERS )

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -140,7 +140,7 @@ def is_authoratative( flags ):
 
 def ns_query( hostname, nameserver_ip, nameserver_hostname ):
     if not hostname.endswith( "." ):
-        hostname += hostname + "."
+        hostname += "."
 
     # Normalize input query data
     hostname = hostname.lower()

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -560,6 +560,7 @@ if __name__ == '__main__':
         '--domain-check',
         dest='domain_check',
         help='Check if nameserver base domains are expired. Specify a Gandi API key.',
+        metavar='GANDI_API_KEY',
     )
     parser.add_argument(
         '-x',

--- a/trusttrees.py
+++ b/trusttrees.py
@@ -567,6 +567,7 @@ if __name__ == '__main__':
         '--export-formats',
         dest='export_formats',
         help='Comma-seperated export formats, e.g: -x png,pdf',
+        default='png',
     )
     args = parser.parse_args()
 
@@ -579,18 +580,14 @@ if __name__ == '__main__':
 
     enumerate_nameservers(target_hostname)
 
+    export_formats = [
+        extension.strip()
+        for extension in
+        args.export_formats.split(',')
+    ]
+    output_graph_file = './output/{}_trust_tree_graph.'.format(target_hostname)
     # Render graph image
     grapher = pgv.AGraph(draw_graph_from_cache(target_hostname))
-
-    output_graph_file = './output/' + target_hostname + '_trust_tree_graph.'
-
-    export_formats = []
-    if args.export_formats:
-        export_parts = args.export_formats.split(',')
-        for part in export_parts:
-            export_formats.append(part.strip())
-    else:
-        export_formats.append('png')
 
     for export_format in export_formats:
         file_name = output_graph_file + export_format


### PR DESCRIPTION
This should have the exact same functionality [as before](https://github.com/mandatoryprogrammer/TrustTrees/blob/785370b009bd1dc03af878c03e0d8c06f4896092/trusttrees.py), I mainly tried to DRY up the code a little while I read it. The git history should make things more clear than the big diff.

~I am going to release the code as it is now on PyPI, before we merge this in.~ (Done.)

Some of the changes are:
- Add pre-commit, run hooks
- Add metavar for domain check argument
- Use default value for --export-formats
- Add ipdb to requirements-dev.txt
- Use dns.rdatatype.NS instead of 2
- Make constants for colors
- Delete dead functions
- More pythonic `not foo in bar` -> `foo not in bar` refactors
- Change max_depth to constant, so it is more DRY
- And refactor loop to list comprehension
- Fix spelling of authoritative w/r/t is_authoritative
- Refactor most string formatting to use .format()
- DRY calling get_graph_data_for_ns_results()
- Make all TODOs the same format
- Add some keyword args where it would add clarity
- `dns_query_error_occured (bool|str)` -> `dns_query_error (None|str)`
- DRY and dedent hadouken code in _ns_query()
- Fix spelling of authoritative in comments
- DRY and dedent code in _enumerate_nameservers()
- Change constant name from `DEFAULT_RESOLVER` to `DNS_WATCH_RESOLVER`
- Standardize imports
- Organize global variables a little