### PR TITLE
Tanx16 add s3 upload image feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ optional arguments:
   -o, --open            Open the generated graph(s) once run.
   --only-problematic    Open generate graphs that are likely to be vulnerable.
   --no-graphing         Do not generate any graphs.
+  -u, --upload-graph    Upload the generated graph to S3 with given prefix,bucket.
+                        Requires PutObject permissions.
   -x EXPORT_FORMATS, --export-formats EXPORT_FORMATS
                         Comma-separated export formats, e.g: -x png,pdf
   --resolvers RESOLVERS_FILE

--- a/trusttrees/__main__.py
+++ b/trusttrees/__main__.py
@@ -44,6 +44,7 @@ def main(command_line_args=sys.argv[1:]):
             export_formats,
             args.only_draw_problematic,
             args.open,
+            args.upload_args,
         )
 
     return 0

--- a/trusttrees/draw.py
+++ b/trusttrees/draw.py
@@ -170,7 +170,7 @@ def generate_graph(
             subprocess.call(['open', filename])
         if upload_args:
             print('[ STATUS ] Uploading to AWS...')
-            prefix, bucket = upload_args.split()
+            prefix, bucket = upload_args.split(',')
             with open(global_state.AWS_CREDS_FILE, 'r') as f:
                 creds = json.load(f)
             client = boto3.client(

--- a/trusttrees/draw.py
+++ b/trusttrees/draw.py
@@ -1,3 +1,4 @@
+import boto3
 import pygraphviz
 
 import subprocess
@@ -144,6 +145,7 @@ def generate_graph(
     export_formats,
     only_draw_problematic,
     open_graph_file,
+    upload_args,
 ):
     output_graph_file = f'./output/{target_hostname}_trust_tree_graph'
 
@@ -166,5 +168,17 @@ def generate_graph(
         if open_graph_file:
             print('[ STATUS ] Opening final graph...')
             subprocess.call(['open', filename])
+        if upload_args:
+            print('[ STATUS ] Uploading to AWS...')
+            prefix, bucket = upload_args.split()
+            with open(global_state.AWS_CREDS_FILE, 'r') as f:
+                creds = json.load(f)
+            client = boto3.client(
+                's3',
+                aws_access_key_id=creds['accessKeyId'],
+                aws_secret_access_key=creds['secretAccessKey'],
+                region_name='us-west-1',
+            )
+            client.upload_file(prefix+filename, bucket, filename)
 
     print('[ SUCCESS ] Finished generating graph!')

--- a/trusttrees/usage.py
+++ b/trusttrees/usage.py
@@ -49,6 +49,14 @@ def _add_optional_args(parser):
     )
 
     optional_group.add_argument(
+        '-u',
+        '--upload-graph',
+        dest='upload_args',
+        help='Comma-separated AWS args, e.g: -u graphs,mybucket',
+        metavar='PREFIX,BUCKET',
+    )
+
+    optional_group.add_argument(
         '--resolvers',
         dest='resolvers',
         help='Text file containing DNS resolvers to use.',


### PR DESCRIPTION
This implements https://github.com/mandatoryprogrammer/TrustTrees/issues/22.
Users can now use `-u [prefix],[bucket]` to specify an s3 bucket to upload the graph to.