### PR TITLE
Add dnsimple v2 support, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ usage: trusttrees (-t TARGET_HOSTNAME | -l TARGET_HOSTNAMES_LIST) [-o]
                   [--aws-credentials AWS_CREDS_FILE]
                   [--gandi-api-v4-key GANDI_API_V4_KEY]
                   [--gandi-api-v5-key GANDI_API_V5_KEY]
+                  [--dnsimple-api-v2-token DNSIMPLE_ACCESS_TOKEN]
 
 Graph out a domain's DNS delegation chain and trust trees!
 
@@ -112,18 +113,21 @@ optional arguments:
                         Text file containing DNS resolvers to use.
 
 optional arguments for domain-checking:
-  --aws-credentials AWS_CREDS_FILE
-                        AWS credentials JSON file for checking if nameserver
-                        base domains are registerable.
-  --gandi-api-v4-key GANDI_API_V4_KEY
-                        Gandi API V4 key for checking if nameserver base
-                        domains are registerable.
-  --gandi-api-v5-key GANDI_API_V5_KEY
-                        Gandi API V5 key for checking if nameserver base
-                        domains are registerable.
+  --aws-credentials       AWS_CREDS_FILE
+                             AWS credentials JSON file for checking if nameserver
+                             base domains are registerable.
+  --gandi-api-v4-key      GANDI_API_V4_KEY
+                             Gandi API V4 key for checking if nameserver base
+                             domains are registerable.
+  --gandi-api-v5-key      GANDI_API_V5_KEY
+                             Gandi API V5 key for checking if nameserver base
+                             domains are registerable.
+  --dnsimple-api-v2-token DNSIMPLE_ACCESS_TOKEN
+                             DNSimple API V2 access token for checking if nameserver
+                             base domains are registerable.
 ```
 
-In order to use the domain-check functionality to look for domain takeovers via expired-domain registration you must have a Gandi production API key or AWS keys with the `route53domains:CheckDomainAvailability` IAM permission. Only Gandi is supported because they are the only registrar we are aware of with a wide range of supported TLDs, a solid API, and good support. (AWS uses Gandi behind the scenes.) [Click here to sign up for a Gandi account.](https://www.gandi.net/)
+In order to use the domain-check functionality to look for domain takeovers via expired-domain registration you must have a Gandi production API key, AWS keys with the `route53domains:CheckDomainAvailability` IAM permission, or a DNSimple access token. AWS uses Gandi behind the scenes. [Click here to sign up for a Gandi account.](https://www.gandi.net/)
 
 ## Graph Nodes/Edges Documentation
 ### Nodes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.9.227
+dnsimple==2.0.0
 dnspython==1.16.0
 pygraphviz==1.5
 requests==2.22.0

--- a/trusttrees/global_state.py
+++ b/trusttrees/global_state.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 
 AWS_CREDS_FILE = ''
+DNSIMPLE_ACCESS_TOKEN = ''
 GANDI_API_V4_KEY = ''
 GANDI_API_V5_KEY = ''
 

--- a/trusttrees/usage.py
+++ b/trusttrees/usage.py
@@ -90,6 +90,12 @@ def _add_optional_args(parser):
         help='Gandi API V5 key for checking if nameserver base domains are registerable.',
         metavar='GANDI_API_V5_KEY',
     )
+    optional_domain_checking_group.add_argument(
+        '--dnsimple-api-v2-token',
+        dest='dnsimple_api_v2_token',
+        help='dnsimple API V2 access token for checking if nameserver base domains are registerable.',
+        metavar='DNSIMPLE_ACCESS_TOKEN',
+    )
 
 
 def parse_args(args):

--- a/trusttrees/utils.py
+++ b/trusttrees/utils.py
@@ -95,6 +95,8 @@ def set_global_state_with_args(args):
         global_state.GANDI_API_V4_KEY = args.gandi_api_v4_key
     elif args.gandi_api_v5_key:
         global_state.GANDI_API_V5_KEY = args.gandi_api_v5_key
+    elif args.dnsimple_api_v2_token:
+        global_state.DNSIMPLE_ACCESS_TOKEN = args.dnsimple_api_v2_token
     else:
         global_state.CHECK_DOMAIN_AVAILABILITY = False
 


### PR DESCRIPTION
This addresses https://github.com/mandatoryprogrammer/TrustTrees/issues/36. I tested this with a sandbox account, i.e. `Client(sandbox=True, access_token='a1b2c3')`. Note that this doesn't use the `@_auto_retry` decorator, as the documentation (see [here](https://developer.dnsimple.com/v2/registrar/#checkDomain)) only returns a boolean.